### PR TITLE
fix integer overflow and segfault on large videos

### DIFF
--- a/src/gui/waveform/zoombuffer.cpp
+++ b/src/gui/waveform/zoombuffer.cpp
@@ -225,8 +225,12 @@ ZoomBuffer::zoomedBuffer(quint32 timeStart, quint32 timeEnd, WaveZoomData **buff
 
 	QMutexLocker l(&m_reqMutex);
 
-	m_reqStart = qMin(timeStart * m_waveBuffer->sampleRate() / m_samplesPerPixel / 1000, m_waveformZoomedSize);
-	m_reqEnd = qMin(timeEnd * m_waveBuffer->sampleRate() / m_samplesPerPixel / 1000, m_waveformZoomedSize);
+	m_reqStart = qMin(static_cast<quint32>(static_cast<quint64>(timeStart)
+										   * m_waveBuffer->sampleRate() / m_samplesPerPixel / 1000),
+					  m_waveformZoomedSize);
+	m_reqEnd = qMin(static_cast<quint32>(static_cast<quint64>(timeEnd)
+										 * m_waveBuffer->sampleRate() / m_samplesPerPixel / 1000),
+					m_waveformZoomedSize);
 	m_reqLen = bufLen;
 
 	for(quint16 ch = 0; ch < m_waveBuffer->channels(); ch++)


### PR DESCRIPTION
An integer overflow in **ZoomBuffer::zoomedBuffer()** would sometimes cause **m_reqEnd** to be less than **m_reqStart**. This was followed by a segfault and a crash.